### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,30 +55,8 @@ or by editing your `go.mod` file as [described by the gomod documentation](https
 `go-libp2p-noise` is not currently enabled by default when constructing a new libp2p
 [Host][godoc-host], so you will need to explicitly enable it in order to use it.
 
-To add `go-libp2p-noise` to the default set of security protocols, you can extend the
-`DefaultSecurity` [package variable in go-libp2p][godoc-go-libp2p-pkg-vars] with
-a new [`Security` option][godoc-security-option] that enables `go-libp2p-noise`:
-
-```go
-package example
-
-import (
-  "context"
-  libp2p "github.com/libp2p/go-libp2p"
-  noise "github.com/libp2p/go-libp2p-noise"
-)
-
-ctx := context.Background() // you may want a more specialized context in the real world
-security := libp2p.ChainOptions(
-  libp2p.DefaultSecurity,
-  libp2p.Security(noise.ID, noise.NewTransport))
-
-host := libp2p.New(ctx, security)
-```
-
-If you _only_ want to use `go-libp2p-noise`, you can simply pass in the `Security` option without chaining it
-to the `DefaultSecurity` variable. However, this will limit the peers you are able to communicate with to just
-those that support the Noise libp2p security protocol.
+The API for constructing a new Noise transport is currently in flux. This README will
+be updated once it stabilizes. 
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ For more information about how `go-libp2p-noise` is used in the libp2p context, 
 
 Feel free to join in. All welcome. Open an [issue](https://github.com/libp2p/go-libp2p-noise/issues)!
 
-This repository falls under the IPFS [Code of Conduct](https://github.com/libp2p/community/blob/master/code-of-conduct.md).
+This repository falls under the libp2p [Code of Conduct](https://github.com/libp2p/community/blob/master/code-of-conduct.md).
 
-### Want to hack on IPFS?
+### Want to hack on libp2p?
 
-[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
+[![](https://cdn.rawgit.com/libp2p/community/master/img/contribute.gif)](https://github.com/libp2p/community/blob/master/CONTRIBUTE.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@
 
 Package `go-libp2p-noise` is a libp2p [stream security transport](https://github.com/libp2p/go-stream-security). Connections wrapped by `noise` use secure sessions provided by this package to encrypt all traffic. A noise protocol handshake is used to setup the communication channel. See the [noise-libp2p spec](https://github.com/libp2p/specs/blob/master/noise/README.md) for more info.
 
+## Status
+
+This implementation is being updated to track some recent changes to the [spec](https://github.com/libp2p/specs/blob/master/noise/README.md):
+
+- [ ] [use of channel binding token to prevent replay attacks](https://github.com/libp2p/specs/pull/234)
+
+We recommend waiting until those changes are in place before adopting go-libp2p-noise for production use.
+
 ## Install
 
 `go-libp2p-noise` is a standard Go module which can be installed with:


### PR DESCRIPTION
This adds some color to the readme, including a status section and usage example.

As I was writing the usage part, I realized that I haven't tried wiring this up to a go-libp2p Host yet. I'm not sure if the [reflection magic](https://github.com/libp2p/go-libp2p/blob/master/config/reflection_magic.go) will play nicely with passing in arguments to the transport constructor (e.g. enabling Noise pipes).

So that part might need to be rewritten a bit after experimenting.