### PR TITLE
Fix noise pipes support

### DIFF
--- a/ik/IK.noise.go
+++ b/ik/IK.noise.go
@@ -409,7 +409,7 @@ func initializeInitiator(prologue []byte, s Keypair, rs [32]byte, psk [32]byte) 
 	var ss symmetricstate
 	var e Keypair
 	var re [32]byte
-	name := []byte("Noise_IK_25519_ChaChaPoly_BLAKE2s")
+	name := []byte("Noise_IK_25519_ChaChaPoly_SHA256")
 	ss = initializeSymmetric(name)
 	mixHash(&ss, prologue)
 	mixHash(&ss, rs[:])
@@ -420,7 +420,7 @@ func initializeResponder(prologue []byte, s Keypair, rs [32]byte, psk [32]byte) 
 	var ss symmetricstate
 	var e Keypair
 	var re [32]byte
-	name := []byte("Noise_IK_25519_ChaChaPoly_BLAKE2s")
+	name := []byte("Noise_IK_25519_ChaChaPoly_SHA256")
 	ss = initializeSymmetric(name)
 	mixHash(&ss, prologue)
 	mixHash(&ss, s.public_key[:])

--- a/ik_handshake.go
+++ b/ik_handshake.go
@@ -60,13 +60,13 @@ func (s *secureSession) ik_recvHandshakeMessage(initial_stage bool) (buf []byte,
 	log.Debugf("ik_recvHandshakeMessage initiator=%v msgbuf=%v", s.initiator, msgbuf)
 
 	if err != nil {
-		log.Error("ik_recvHandshakeMessage initiator=%v decode err=%s", s.initiator, err)
+		log.Errorf("ik_recvHandshakeMessage initiator=%v decode err=%s", s.initiator, err)
 		return buf, nil, false, fmt.Errorf("ik_recvHandshakeMessage decode msg fail: %s", err)
 	}
 
 	s.ik_ns, plaintext, valid = ik.RecvMessage(s.ik_ns, msgbuf)
 	if !valid {
-		log.Error("ik_recvHandshakeMessage initiator=%v err=%s", s.initiator, "validation fail")
+		log.Errorf("ik_recvHandshakeMessage initiator=%v err=%s", s.initiator, "validation fail")
 		return buf, nil, false, fmt.Errorf("ik_recvHandshakeMessage validation fail")
 	}
 

--- a/protocol.go
+++ b/protocol.go
@@ -194,10 +194,9 @@ func (s *secureSession) runHandshake(ctx context.Context) error {
 			}
 
 			s.xx_complete = true
+		} else {
+			s.ik_complete = true
 		}
-
-		s.ik_complete = true
-
 	} else {
 		// unknown static key for peer, try XX
 		err := s.runHandshake_xx(ctx, false, payloadEnc, nil)

--- a/transport_test.go
+++ b/transport_test.go
@@ -80,15 +80,15 @@ func newConnPair(t *testing.T) (net.Conn, net.Conn) {
 func connect(t *testing.T, initTransport, respTransport *Transport) (*secureSession, *secureSession) {
 	init, resp := newConnPair(t)
 
-	var respConn sec.SecureConn
-	var respErr error
+	var initConn sec.SecureConn
+	var initErr error
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		respConn, respErr = respTransport.SecureOutbound(context.TODO(), resp, initTransport.LocalID)
+		initConn, initErr = initTransport.SecureOutbound(context.TODO(), init, respTransport.LocalID)
 	}()
 
-	initConn, initErr := initTransport.SecureInbound(context.TODO(), init)
+	respConn, respErr := respTransport.SecureInbound(context.TODO(), resp)
 	<-done
 
 	if initErr != nil {

--- a/transport_test.go
+++ b/transport_test.go
@@ -176,25 +176,17 @@ func TestHandshakeXX(t *testing.T) {
 
 // Test IK handshake
 func TestHandshakeIK(t *testing.T) {
-	initTransport := newTestTransport(t, crypto.Ed25519, 2048)
-	respTransport := newTestTransport(t, crypto.Ed25519, 2048)
-
-	// do initial XX handshake
-	initConn, respConn := connect(t, initTransport, respTransport)
-	initConn.Close()
-	respConn.Close()
-
-	// turn on pipes, this will turn on IK
-	initTransport.NoisePipesSupport = true
-	respTransport.NoisePipesSupport = true
+	initTransport := newTestTransportPipes(t, crypto.Ed25519, 2048)
+	respTransport := newTestTransportPipes(t, crypto.Ed25519, 2048)
 
 	// add responder's static key to initiator's key cache
+	respTransport.NoiseKeypair = GenerateKeypair()
 	keycache := make(map[peer.ID]([32]byte))
 	keycache[respTransport.LocalID] = respTransport.NoiseKeypair.public_key
 	initTransport.NoiseStaticKeyCache = keycache
 
 	// do IK handshake
-	initConn, respConn = connect(t, initTransport, respTransport)
+	initConn, respConn := connect(t, initTransport, respTransport)
 	defer initConn.Close()
 	defer respConn.Close()
 
@@ -212,6 +204,11 @@ func TestHandshakeIK(t *testing.T) {
 
 	if !bytes.Equal(before, after) {
 		t.Errorf("Message mismatch. %v != %v", before, after)
+	}
+
+	// make sure IK was actually used
+	if !(initConn.ik_complete && respConn.ik_complete) {
+		t.Error("Expected IK handshake to be used")
 	}
 }
 
@@ -240,5 +237,10 @@ func TestHandshakeXXfallback(t *testing.T) {
 
 	if !bytes.Equal(before, after) {
 		t.Errorf("Message mismatch. %v != %v", before, after)
+	}
+
+	// make sure XX was actually used
+	if !(initConn.xx_complete && respConn.xx_complete) {
+		t.Error("Expected XXfallback handshake to be used")
 	}
 }

--- a/xx_handshake.go
+++ b/xx_handshake.go
@@ -202,7 +202,7 @@ func (s *secureSession) runHandshake_xx(ctx context.Context, fallback bool, payl
 
 		} else {
 			var msgbuf *xx.MessageBuffer
-			msgbuf, err = xx.Decode1(initialMsg)
+			msgbuf, err = xx.Decode0(initialMsg)
 			if err != nil {
 				log.Errorf("runHandshake_xx recv msg err", err)
 				return err


### PR DESCRIPTION
This closes #4 by fixing a few things that were preventing the IK handshake from occurring when Noise pipes is enabled:

- fixes the `connect` test helper method to use the right roles for initiator and responder
- updates the `TestHandshakeIK` and `TestHandshakeXXfallback` tests to make sure the expected handshake was actually used
- fixes the conditional in `runHanshake` that controls whether to try `IK`
- fixes a bug that was causing `XXfallback` to decode the initial IK message as message 1 of the XX sequence instead of message 0

Not related to Noise pipes, but fixed along the way:

- updates the Noise protocol name strings in the generated IK code to use `SHA256` instead of `BLAKE2b` as the hash function
