### PR TITLE
rename imports from ChainSafe to libp2p org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](https://libp2p.io/)
 [![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 [![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
-[![GoDoc](https://godoc.org/github.com/ChainSafe/go-libp2p-noise?status.svg)](https://godoc.org/github.com/ChainSafe/go-libp2p-noise)
-[![Build Status](https://travis-ci.org/ChainSafe/go-libp2p-noise.svg?branch=master)](https://travis-ci.org/ChainSafe/go-libp2p-noise)
+[![GoDoc](https://godoc.org/github.com/libp2p/go-libp2p-noise?status.svg)](https://godoc.org/github.com/libp2p/go-libp2p-noise)
+[![Build Status](https://travis-ci.org/libp2p/go-libp2p-noise.svg?branch=master)](https://travis-ci.org/libp2p/go-libp2p-noise)
 
 > go-libp2p's noise encrypted transport
 

--- a/crypto.go
+++ b/crypto.go
@@ -2,8 +2,8 @@ package noise
 
 import (
 	"errors"
-	ik "github.com/ChainSafe/go-libp2p-noise/ik"
-	xx "github.com/ChainSafe/go-libp2p-noise/xx"
+	ik "github.com/libp2p/go-libp2p-noise/ik"
+	xx "github.com/libp2p/go-libp2p-noise/xx"
 )
 
 func (s *secureSession) Encrypt(plaintext []byte) (ciphertext []byte, err error) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ChainSafe/go-libp2p-noise
+module github.com/libp2p/go-libp2p-noise
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/ChainSafe/go-libp2p-noise v0.0.0-20190823200153-4f1b35c795df h1:3CoDUlyzOj67mNWYJqnihg97m7Bb4cjLmY6Hif0JseA=
+github.com/libp2p/go-libp2p-noise v0.0.0-20190823200153-4f1b35c795df h1:3CoDUlyzOj67mNWYJqnihg97m7Bb4cjLmY6Hif0JseA=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=

--- a/ik/IK_test.go
+++ b/ik/IK_test.go
@@ -2,9 +2,9 @@ package ik
 
 import (
 	"crypto/rand"
-	pb "github.com/ChainSafe/go-libp2p-noise/pb"
 	proto "github.com/gogo/protobuf/proto"
 	"github.com/libp2p/go-libp2p-core/crypto"
+	pb "github.com/libp2p/go-libp2p-noise/pb"
 	"testing"
 )
 

--- a/ik_handshake.go
+++ b/ik_handshake.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	ik "github.com/ChainSafe/go-libp2p-noise/ik"
-	pb "github.com/ChainSafe/go-libp2p-noise/pb"
 	proto "github.com/gogo/protobuf/proto"
+	ik "github.com/libp2p/go-libp2p-noise/ik"
+	pb "github.com/libp2p/go-libp2p-noise/pb"
 )
 
 func (s *secureSession) ik_sendHandshakeMessage(payload []byte, initial_stage bool) error {

--- a/protocol.go
+++ b/protocol.go
@@ -13,9 +13,9 @@ import (
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 
-	ik "github.com/ChainSafe/go-libp2p-noise/ik"
-	pb "github.com/ChainSafe/go-libp2p-noise/pb"
-	xx "github.com/ChainSafe/go-libp2p-noise/xx"
+	ik "github.com/libp2p/go-libp2p-noise/ik"
+	pb "github.com/libp2p/go-libp2p-noise/pb"
+	xx "github.com/libp2p/go-libp2p-noise/xx"
 )
 
 const payload_string = "noise-libp2p-static-key:"

--- a/transport_test.go
+++ b/transport_test.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"testing"
 
-	//ik "github.com/ChainSafe/go-libp2p-noise/ik"
+	//ik "github.com/libp2p/go-libp2p-noise/ik"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/sec"

--- a/xx/XX_test.go
+++ b/xx/XX_test.go
@@ -3,9 +3,9 @@ package xx
 import (
 	"crypto/rand"
 	"encoding/hex"
-	pb "github.com/ChainSafe/go-libp2p-noise/pb"
 	proto "github.com/gogo/protobuf/proto"
 	"github.com/libp2p/go-libp2p-core/crypto"
+	pb "github.com/libp2p/go-libp2p-noise/pb"
 	"testing"
 )
 

--- a/xx_handshake.go
+++ b/xx_handshake.go
@@ -7,8 +7,8 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	"github.com/libp2p/go-libp2p-core/peer"
 
-	pb "github.com/ChainSafe/go-libp2p-noise/pb"
-	xx "github.com/ChainSafe/go-libp2p-noise/xx"
+	pb "github.com/libp2p/go-libp2p-noise/pb"
+	xx "github.com/libp2p/go-libp2p-noise/xx"
 )
 
 func (s *secureSession) xx_sendHandshakeMessage(payload []byte, initial_stage bool) error {


### PR DESCRIPTION
this changes all the references to `ChainSafe/go-libp2p-noise` to `libp2p/go-libp2p-noise`