### PR TITLE
guard static key cache with mutex

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -75,8 +75,8 @@ func makeNodePipes(t *testing.T, seed int64, port int, rpid peer.ID, rpubkey [32
 	}
 
 	tpt := NewTransport(pid, priv, true, kp)
-	tpt.NoiseStaticKeyCache = make(map[peer.ID]([32]byte))
-	tpt.NoiseStaticKeyCache[rpid] = rpubkey
+	tpt.NoiseStaticKeyCache = NewKeyCache()
+	tpt.NoiseStaticKeyCache.Store(rpid, rpubkey)
 
 	ip := "0.0.0.0"
 	addr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ip, port))

--- a/keycache.go
+++ b/keycache.go
@@ -1,0 +1,30 @@
+package noise
+
+import (
+	"github.com/libp2p/go-libp2p-core/peer"
+	"sync"
+)
+
+type KeyCache struct {
+	lock sync.RWMutex
+	m    map[peer.ID][32]byte
+}
+
+func NewKeyCache() *KeyCache {
+	return &KeyCache{
+		lock: sync.RWMutex{},
+		m:    make(map[peer.ID][32]byte),
+	}
+}
+
+func (kc *KeyCache) Store(p peer.ID, key [32]byte) {
+	kc.lock.Lock()
+	kc.m[p] = key
+	kc.lock.Unlock()
+}
+
+func (kc *KeyCache) Load(p peer.ID) [32]byte {
+	kc.lock.RLock()
+	defer kc.lock.RUnlock()
+	return kc.m[p]
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -220,8 +220,8 @@ func TestHandshakeIK(t *testing.T) {
 
 	// add responder's static key to initiator's key cache
 	respTransport.NoiseKeypair = GenerateKeypair()
-	keycache := make(map[peer.ID]([32]byte))
-	keycache[respTransport.LocalID] = respTransport.NoiseKeypair.public_key
+	keycache := NewKeyCache()
+	keycache.Store(respTransport.LocalID, respTransport.NoiseKeypair.public_key)
 	initTransport.NoiseStaticKeyCache = keycache
 
 	// do IK handshake

--- a/xx_handshake.go
+++ b/xx_handshake.go
@@ -178,7 +178,7 @@ func (s *secureSession) runHandshake_xx(ctx context.Context, fallback bool, payl
 		}
 
 		if s.noisePipesSupport {
-			s.noiseStaticKeyCache[s.remotePeer] = s.xx_ns.RemoteKey()
+			s.noiseStaticKeyCache.Store(s.remotePeer, s.xx_ns.RemoteKey())
 		}
 
 	} else {
@@ -268,7 +268,7 @@ func (s *secureSession) runHandshake_xx(ctx context.Context, fallback bool, payl
 		}
 
 		if s.noisePipesSupport {
-			s.noiseStaticKeyCache[s.remotePeer] = s.remote.noiseKey
+			s.noiseStaticKeyCache.Store(s.remotePeer, s.remote.noiseKey)
 		}
 	}
 


### PR DESCRIPTION
This closes #5 by guarding the static key cache with a `sync.RWMutex`, now bundled in a wrapper struct called `KeyCache`.

Thanks to @marten-seemann for steering me away from `sync.Map`, which does seem like it's only useful in rare cases.
