### PR TITLE
Assorted cleanup

### DIFF
--- a/ik_handshake.go
+++ b/ik_handshake.go
@@ -80,7 +80,7 @@ func (s *secureSession) ik_recvHandshakeMessage(initial_stage bool) (buf []byte,
 //     <- e, ee, se
 // returns last successful message upon error
 func (s *secureSession) runHandshake_ik(ctx context.Context, payload []byte) ([]byte, error) {
-	kp := ik.NewKeypair(s.noiseKeypair.public_key, s.noiseKeypair.private_key)
+	kp := ik.NewKeypair(s.noiseKeypair.publicKey, s.noiseKeypair.privateKey)
 
 	log.Debugf("runHandshake_ik initiator=%v pubkey=%x", kp.PubKey(), s.initiator)
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -159,7 +159,7 @@ func TestLibp2pIntegration_WithPipes(t *testing.T) {
 
 	defer ha.Close()
 
-	hb, err := makeNodePipes(t, 2, 34343, ha.ID(), kpa.public_key, nil)
+	hb, err := makeNodePipes(t, 2, 34343, ha.ID(), kpa.publicKey, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +216,7 @@ func TestLibp2pIntegration_XXFallback(t *testing.T) {
 
 	defer ha.Close()
 
-	hb, err := makeNodePipes(t, 2, 34343, ha.ID(), kpa.public_key, nil)
+	hb, err := makeNodePipes(t, 2, 34343, ha.ID(), kpa.publicKey, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -71,8 +71,8 @@ func makeNodePipes(t *testing.T, seed int64, port int, rpid peer.ID, rpubkey [32
 		t.Fatal(err)
 	}
 
-	tpt.NoiseStaticKeyCache = NewKeyCache()
-	tpt.NoiseStaticKeyCache.Store(rpid, rpubkey)
+	tpt.noiseStaticKeyCache = NewKeyCache()
+	tpt.noiseStaticKeyCache.Store(rpid, rpubkey)
 
 	ip := "0.0.0.0"
 	addr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ip, port))

--- a/keys.go
+++ b/keys.go
@@ -7,18 +7,18 @@ import (
 
 // Keypair is a noise ed25519 public-private keypair
 type Keypair struct {
-	public_key  [32]byte
-	private_key [32]byte
+	publicKey  [32]byte
+	privateKey [32]byte
 }
 
 // GenerateKeypair creates a new ed25519 keypair
 func GenerateKeypair() (*Keypair, error) {
-	var public_key [32]byte
-	var private_key [32]byte
-	_, err := rand.Read(private_key[:])
+	var publicKey [32]byte
+	var privateKey [32]byte
+	_, err := rand.Read(privateKey[:])
 	if err != nil {
 		return nil, err
 	}
-	curve25519.ScalarBaseMult(&public_key, &private_key)
-	return &Keypair{public_key, private_key}, nil
+	curve25519.ScalarBaseMult(&publicKey, &privateKey)
+	return &Keypair{publicKey, privateKey}, nil
 }

--- a/keys.go
+++ b/keys.go
@@ -1,0 +1,24 @@
+package noise
+
+import (
+	"crypto/rand"
+	"golang.org/x/crypto/curve25519"
+)
+
+// Keypair is a noise ed25519 public-private keypair
+type Keypair struct {
+	public_key  [32]byte
+	private_key [32]byte
+}
+
+// GenerateKeypair creates a new ed25519 keypair
+func GenerateKeypair() (*Keypair, error) {
+	var public_key [32]byte
+	var private_key [32]byte
+	_, err := rand.Read(private_key[:])
+	if err != nil {
+		return nil, err
+	}
+	curve25519.ScalarBaseMult(&public_key, &private_key)
+	return &Keypair{public_key, private_key}, nil
+}

--- a/options.go
+++ b/options.go
@@ -9,7 +9,7 @@ package noise
 // using XX in the first place, however there is a slight processing overhead
 // due to the initial decryption attempt of the IK message.
 func UseNoisePipes(cfg *config) {
-	cfg.NoisePipesSupport = true
+	cfg.noisePipesSupport = true
 }
 
 // NoiseKeyPair configures the Noise transport to use the given Noise static
@@ -24,13 +24,13 @@ func UseNoisePipes(cfg *config) {
 // take care to store the key securely!
 func NoiseKeyPair(kp *Keypair) Option {
 	return func(cfg *config) {
-		cfg.NoiseKeypair = kp
+		cfg.noiseKeypair = kp
 	}
 }
 
 type config struct {
-	NoiseKeypair      *Keypair
-	NoisePipesSupport bool
+	noiseKeypair      *Keypair
+	noisePipesSupport bool
 }
 
 type Option func(cfg *config)

--- a/protocol.go
+++ b/protocol.go
@@ -3,6 +3,7 @@ package noise
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -26,6 +27,8 @@ const payload_string = "noise-libp2p-static-key:"
 const maxPlaintextLength = 65519
 
 var log = logging.Logger("noise")
+
+var errNoKeypair = errors.New("cannot initiate secureSession - transport has no noise keypair")
 
 type secureSession struct {
 	insecure net.Conn
@@ -60,45 +63,42 @@ type peerInfo struct {
 	libp2pKey crypto.PubKey
 }
 
-// newSecureSession creates a noise session that can be configured to be initialized with a static
-// noise key `noisePrivateKey`, a cache of previous peer noise keys `noiseStaticKeyCache`, an
-// option `noisePipesSupport` to turn on or off noise pipes
+// newSecureSession creates a noise session over the given insecure Conn, using the static
+// Noise keypair and libp2p identity keypair from the given Transport.
 //
-// With noise pipes off, we always do XX
-// With noise pipes on, we first try IK, if that fails, move to XXfallback
-func newSecureSession(ctx context.Context, local peer.ID, privKey crypto.PrivKey, kp *Keypair,
-	insecure net.Conn, remote peer.ID, noiseStaticKeyCache *KeyCache,
-	noisePipesSupport bool, initiator bool) (*secureSession, error) {
-
-	if noiseStaticKeyCache == nil {
-		noiseStaticKeyCache = NewKeyCache()
+// If tpt.noisePipesSupport == true, the Noise Pipes handshake protocol will be used,
+// which consists of the IK and XXfallback handshake patterns. With Noise Pipes on, we first try IK,
+// if that fails, move to XXfallback. With Noise Pipes off, we always do XX.
+func newSecureSession(tpt *Transport, ctx context.Context, insecure net.Conn, remote peer.ID, initiator bool) (*secureSession, error) {
+	if tpt.noiseKeypair == nil {
+		return nil, errNoKeypair
 	}
 
-	if kp == nil {
-		var err error
-		kp, err = GenerateKeypair()
-		if err != nil {
-			return nil, err
-		}
+	// if the transport doesn't have a key cache, we make a new one just for
+	// this session. it's a bit of a waste, but saves us having to check if
+	// it's nil later
+	keyCache := tpt.noiseStaticKeyCache
+	if keyCache == nil {
+		keyCache = NewKeyCache()
 	}
 
 	localPeerInfo := peerInfo{
-		noiseKey:  kp.publicKey,
-		libp2pKey: privKey.GetPublic(),
+		noiseKey:  tpt.noiseKeypair.publicKey,
+		libp2pKey: tpt.privateKey.GetPublic(),
 	}
 
 	s := &secureSession{
 		insecure:            insecure,
 		initiator:           initiator,
 		prologue:            []byte(ID),
-		localKey:            privKey,
-		localPeer:           local,
+		localKey:            tpt.privateKey,
+		localPeer:           tpt.localID,
 		remotePeer:          remote,
 		local:               localPeerInfo,
-		noisePipesSupport:   noisePipesSupport,
-		noiseStaticKeyCache: noiseStaticKeyCache,
+		noisePipesSupport:   tpt.noisePipesSupport,
+		noiseStaticKeyCache: keyCache,
 		msgBuffer:           []byte{},
-		noiseKeypair:        kp,
+		noiseKeypair:        tpt.noiseKeypair,
 	}
 
 	err := s.runHandshake(ctx)

--- a/protocol.go
+++ b/protocol.go
@@ -83,7 +83,7 @@ func newSecureSession(ctx context.Context, local peer.ID, privKey crypto.PrivKey
 	}
 
 	localPeerInfo := peerInfo{
-		noiseKey:  kp.public_key,
+		noiseKey:  kp.publicKey,
 		libp2pKey: privKey.GetPublic(),
 	}
 
@@ -111,11 +111,11 @@ func (s *secureSession) NoiseStaticKeyCache() *KeyCache {
 }
 
 func (s *secureSession) NoisePublicKey() [32]byte {
-	return s.noiseKeypair.public_key
+	return s.noiseKeypair.publicKey
 }
 
 func (s *secureSession) NoisePrivateKey() [32]byte {
-	return s.noiseKeypair.private_key
+	return s.noiseKeypair.privateKey
 }
 
 func (s *secureSession) readLength() (int, error) {
@@ -165,7 +165,7 @@ func (s *secureSession) runHandshake(ctx context.Context) error {
 	}
 
 	// sign noise data for payload
-	noise_pub := s.noiseKeypair.public_key
+	noise_pub := s.noiseKeypair.publicKey
 	signedPayload, err := s.localKey.Sign(append([]byte(payload_string), noise_pub[:]...))
 	if err != nil {
 		log.Errorf("runHandshake signing payload err=%s", err)

--- a/protocol.go
+++ b/protocol.go
@@ -90,7 +90,7 @@ func newSecureSession(tpt *Transport, ctx context.Context, insecure net.Conn, re
 	s := &secureSession{
 		insecure:            insecure,
 		initiator:           initiator,
-		prologue:            []byte(ID),
+		prologue:            []byte{},
 		localKey:            tpt.privateKey,
 		localPeer:           tpt.localID,
 		remotePeer:          remote,

--- a/transport.go
+++ b/transport.go
@@ -2,10 +2,7 @@ package noise
 
 import (
 	"context"
-	"crypto/rand"
 	"net"
-
-	"golang.org/x/crypto/curve25519"
 
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -16,24 +13,6 @@ import (
 const ID = "/noise"
 
 var _ sec.SecureTransport = &Transport{}
-
-// Keypair is a noise ed25519 public-private keypair
-type Keypair struct {
-	public_key  [32]byte
-	private_key [32]byte
-}
-
-// GenerateKeypair creates a new ed25519 keypair
-func GenerateKeypair() (*Keypair, error) {
-	var public_key [32]byte
-	var private_key [32]byte
-	_, err := rand.Read(private_key[:])
-	if err != nil {
-		return nil, err
-	}
-	curve25519.ScalarBaseMult(&public_key, &private_key)
-	return &Keypair{public_key, private_key}, nil
-}
 
 // Transport implements the interface sec.SecureTransport
 // https://godoc.org/github.com/libp2p/go-libp2p-core/sec#SecureConn

--- a/transport.go
+++ b/transport.go
@@ -17,11 +17,11 @@ var _ sec.SecureTransport = &Transport{}
 // Transport implements the interface sec.SecureTransport
 // https://godoc.org/github.com/libp2p/go-libp2p-core/sec#SecureConn
 type Transport struct {
-	LocalID             peer.ID
-	PrivateKey          crypto.PrivKey
-	NoisePipesSupport   bool
-	NoiseStaticKeyCache *KeyCache
-	NoiseKeypair        *Keypair
+	localID             peer.ID
+	privateKey          crypto.PrivKey
+	noisePipesSupport   bool
+	noiseStaticKeyCache *KeyCache
+	noiseKeypair        *Keypair
 }
 
 type transportConstructor func(crypto.PrivKey) (*Transport, error)
@@ -82,7 +82,7 @@ func New(privkey crypto.PrivKey, options ...Option) (*Transport, error) {
 	cfg := config{}
 	cfg.applyOptions(options...)
 
-	kp := cfg.NoiseKeypair
+	kp := cfg.noiseKeypair
 	if kp == nil {
 		kp, err = GenerateKeypair()
 		if err != nil {
@@ -92,37 +92,37 @@ func New(privkey crypto.PrivKey, options ...Option) (*Transport, error) {
 
 	// the static key cache is only useful if Noise Pipes is enabled
 	var keyCache *KeyCache
-	if cfg.NoisePipesSupport {
+	if cfg.noisePipesSupport {
 		keyCache = NewKeyCache()
 	}
 
 	return &Transport{
-		LocalID:             localID,
-		PrivateKey:          privkey,
-		NoisePipesSupport:   cfg.NoisePipesSupport,
-		NoiseKeypair:        kp,
-		NoiseStaticKeyCache: keyCache,
+		localID:             localID,
+		privateKey:          privkey,
+		noisePipesSupport:   cfg.noisePipesSupport,
+		noiseKeypair:        kp,
+		noiseStaticKeyCache: keyCache,
 	}, nil
 }
 
 // SecureInbound runs noise handshake as the responder
 func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn) (sec.SecureConn, error) {
-	s, err := newSecureSession(ctx, t.LocalID, t.PrivateKey, t.NoiseKeypair, insecure, "", t.NoiseStaticKeyCache, t.NoisePipesSupport, false)
+	s, err := newSecureSession(ctx, t.localID, t.privateKey, t.noiseKeypair, insecure, "", t.noiseStaticKeyCache, t.noisePipesSupport, false)
 	if err != nil {
 		return s, err
 	}
 
-	t.NoiseKeypair = s.noiseKeypair
+	t.noiseKeypair = s.noiseKeypair
 	return s, nil
 }
 
 // SecureOutbound runs noise handshake as the initiator
 func (t *Transport) SecureOutbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	s, err := newSecureSession(ctx, t.LocalID, t.PrivateKey, t.NoiseKeypair, insecure, p, t.NoiseStaticKeyCache, t.NoisePipesSupport, true)
+	s, err := newSecureSession(ctx, t.localID, t.privateKey, t.noiseKeypair, insecure, p, t.noiseStaticKeyCache, t.noisePipesSupport, true)
 	if err != nil {
 		return s, err
 	}
 
-	t.NoiseKeypair = s.noiseKeypair
+	t.noiseKeypair = s.noiseKeypair
 	return s, nil
 }

--- a/transport.go
+++ b/transport.go
@@ -107,22 +107,10 @@ func New(privkey crypto.PrivKey, options ...Option) (*Transport, error) {
 
 // SecureInbound runs noise handshake as the responder
 func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn) (sec.SecureConn, error) {
-	s, err := newSecureSession(ctx, t.localID, t.privateKey, t.noiseKeypair, insecure, "", t.noiseStaticKeyCache, t.noisePipesSupport, false)
-	if err != nil {
-		return s, err
-	}
-
-	t.noiseKeypair = s.noiseKeypair
-	return s, nil
+	return newSecureSession(t, ctx, insecure, "", false)
 }
 
 // SecureOutbound runs noise handshake as the initiator
 func (t *Transport) SecureOutbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	s, err := newSecureSession(ctx, t.localID, t.privateKey, t.noiseKeypair, insecure, p, t.noiseStaticKeyCache, t.noisePipesSupport, true)
-	if err != nil {
-		return s, err
-	}
-
-	t.noiseKeypair = s.noiseKeypair
-	return s, nil
+	return newSecureSession(t, ctx, insecure, p, true)
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -225,7 +225,7 @@ func TestHandshakeIK(t *testing.T) {
 	}
 	respTransport.NoiseKeypair = kp
 	keycache := NewKeyCache()
-	keycache.Store(respTransport.LocalID, respTransport.NoiseKeypair.public_key)
+	keycache.Store(respTransport.LocalID, respTransport.NoiseKeypair.publicKey)
 	initTransport.NoiseStaticKeyCache = keycache
 
 	// do IK handshake

--- a/transport_test.go
+++ b/transport_test.go
@@ -23,8 +23,8 @@ func newTestTransport(t *testing.T, typ, bits int) *Transport {
 		t.Fatal(err)
 	}
 	return &Transport{
-		LocalID:    id,
-		PrivateKey: priv,
+		localID:    id,
+		privateKey: priv,
 	}
 }
 
@@ -38,9 +38,9 @@ func newTestTransportPipes(t *testing.T, typ, bits int) *Transport {
 		t.Fatal(err)
 	}
 	return &Transport{
-		LocalID:           id,
-		PrivateKey:        priv,
-		NoisePipesSupport: true,
+		localID:           id,
+		privateKey:        priv,
+		noisePipesSupport: true,
 	}
 }
 
@@ -86,7 +86,7 @@ func connect(t *testing.T, initTransport, respTransport *Transport) (*secureSess
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		initConn, initErr = initTransport.SecureOutbound(context.TODO(), init, respTransport.LocalID)
+		initConn, initErr = initTransport.SecureOutbound(context.TODO(), init, respTransport.localID)
 	}()
 
 	respConn, respErr := respTransport.SecureInbound(context.TODO(), resp)
@@ -111,11 +111,11 @@ func TestIDs(t *testing.T) {
 	defer initConn.Close()
 	defer respConn.Close()
 
-	if initConn.LocalPeer() != initTransport.LocalID {
+	if initConn.LocalPeer() != initTransport.localID {
 		t.Fatal("Initiator Local Peer ID mismatch.")
 	}
 
-	if respConn.RemotePeer() != initTransport.LocalID {
+	if respConn.RemotePeer() != initTransport.localID {
 		t.Fatal("Responder Remote Peer ID mismatch.")
 	}
 
@@ -124,8 +124,8 @@ func TestIDs(t *testing.T) {
 	}
 
 	// TODO: check after stage 0 of handshake if updated
-	if initConn.RemotePeer() != respTransport.LocalID {
-		t.Errorf("Initiator Remote Peer ID mismatch. expected %x got %x", respTransport.LocalID, initConn.RemotePeer())
+	if initConn.RemotePeer() != respTransport.localID {
+		t.Errorf("Initiator Remote Peer ID mismatch. expected %x got %x", respTransport.localID, initConn.RemotePeer())
 	}
 }
 
@@ -140,7 +140,7 @@ func TestKeys(t *testing.T) {
 	sk := respConn.LocalPrivateKey()
 	pk := sk.GetPublic()
 
-	if !sk.Equals(respTransport.PrivateKey) {
+	if !sk.Equals(respTransport.privateKey) {
 		t.Error("Private key Mismatch.")
 	}
 
@@ -223,10 +223,10 @@ func TestHandshakeIK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	respTransport.NoiseKeypair = kp
+	respTransport.noiseKeypair = kp
 	keycache := NewKeyCache()
-	keycache.Store(respTransport.LocalID, respTransport.NoiseKeypair.publicKey)
-	initTransport.NoiseStaticKeyCache = keycache
+	keycache.Store(respTransport.localID, respTransport.noiseKeypair.publicKey)
+	initTransport.noiseStaticKeyCache = keycache
 
 	// do IK handshake
 	initConn, respConn := connect(t, initTransport, respTransport)

--- a/xx_handshake.go
+++ b/xx_handshake.go
@@ -82,7 +82,7 @@ func (s *secureSession) xx_recvHandshakeMessage(initial_stage bool) (buf []byte,
 // if fallback = true, initialMsg is used as the message in stage 1 of the initiator and stage 0
 // of the responder
 func (s *secureSession) runHandshake_xx(ctx context.Context, fallback bool, payload []byte, initialMsg []byte) (err error) {
-	kp := xx.NewKeypair(s.noiseKeypair.public_key, s.noiseKeypair.private_key)
+	kp := xx.NewKeypair(s.noiseKeypair.publicKey, s.noiseKeypair.privateKey)
 
 	log.Debugf("runHandshake_xx initiator=%v fallback=%v pubkey=%x", s.initiator, fallback, kp.PubKey())
 


### PR DESCRIPTION
This cleans up a few things:

- moves the Keypair type and GenerateKeypair out of transport.go to keys.go
- renames Keypair fields to camel case
- makes fields in the Transport and config structs private
- requires that the noise keypair be initialized on the Transport before a session is initiated, instead of generating a keypair in the session and setting the transport keypair after the session handshake is complete
  - this makes the `SecureInbound` and `SecureOutbound` functions much simpler - they now just pass directly through to `secureSession`
  - also gets rid of a potential race condition if two sessions are initiated simultaneously when no keypair exists on the transport
- changes the `secureSession` constructor function so that it accepts a Transport struct and grabs configuration params from it, instead of passing each param separately (local id, libp2p key, noise keys, etc)