### PR TITLE
Make sure we actually read and write as much data as we expect

### DIFF
--- a/ik_handshake.go
+++ b/ik_handshake.go
@@ -28,7 +28,7 @@ func (s *secureSession) ik_sendHandshakeMessage(payload []byte, initial_stage bo
 	}
 
 	// send message
-	_, err = s.insecure.Write(encMsgBuf)
+	_, err = writeAll(s.insecure, encMsgBuf)
 	if err != nil {
 		log.Error("ik_sendHandshakeMessage initiator=%v err=%s", s.initiator, err)
 		return fmt.Errorf("ik_sendHandshakeMessage write to conn err=%s", err)
@@ -45,7 +45,7 @@ func (s *secureSession) ik_recvHandshakeMessage(initial_stage bool) (buf []byte,
 
 	buf = make([]byte, l)
 
-	_, err = s.insecure.Read(buf)
+	_, err = fillBuffer(buf, s.insecure)
 	if err != nil {
 		return buf, nil, false, fmt.Errorf("ik_recvHandshakeMessage read from conn err=%s", err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -17,6 +17,8 @@ import (
 	"time"
 )
 
+const testProtocolID = "/test/noise/integration"
+
 func generateKey(seed int64) (crypto.PrivKey, error) {
 	var r io.Reader
 	if seed == 0 {
@@ -109,8 +111,8 @@ func TestLibp2pIntegration_NoPipes(t *testing.T) {
 
 	defer hb.Close()
 
-	ha.SetStreamHandler(ID, handleStream)
-	hb.SetStreamHandler(ID, handleStream)
+	ha.SetStreamHandler(testProtocolID, handleStream)
+	hb.SetStreamHandler(testProtocolID, handleStream)
 
 	addr, err := ma.NewMultiaddr(fmt.Sprintf("%s/p2p/%s", hb.Addrs()[0].String(), hb.ID()))
 	if err != nil {
@@ -129,7 +131,7 @@ func TestLibp2pIntegration_NoPipes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stream, err := ha.NewStream(ctx, hb.ID(), ID)
+	stream, err := ha.NewStream(ctx, hb.ID(), testProtocolID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,8 +168,8 @@ func TestLibp2pIntegration_WithPipes(t *testing.T) {
 
 	defer hb.Close()
 
-	ha.SetStreamHandler(ID, handleStream)
-	hb.SetStreamHandler(ID, handleStream)
+	ha.SetStreamHandler(testProtocolID, handleStream)
+	hb.SetStreamHandler(testProtocolID, handleStream)
 
 	addr, err := ma.NewMultiaddr(fmt.Sprintf("%s/p2p/%s", ha.Addrs()[0].String(), ha.ID()))
 	if err != nil {
@@ -186,7 +188,7 @@ func TestLibp2pIntegration_WithPipes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stream, err := hb.NewStream(ctx, ha.ID(), ID)
+	stream, err := hb.NewStream(ctx, ha.ID(), testProtocolID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,8 +225,8 @@ func TestLibp2pIntegration_XXFallback(t *testing.T) {
 
 	defer hb.Close()
 
-	ha.SetStreamHandler(ID, handleStream)
-	hb.SetStreamHandler(ID, handleStream)
+	ha.SetStreamHandler(testProtocolID, handleStream)
+	hb.SetStreamHandler(testProtocolID, handleStream)
 
 	addr, err := ma.NewMultiaddr(fmt.Sprintf("%s/p2p/%s", hb.Addrs()[0].String(), hb.ID()))
 	if err != nil {
@@ -243,7 +245,7 @@ func TestLibp2pIntegration_XXFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stream, err := hb.NewStream(ctx, ha.ID(), ID)
+	stream, err := hb.NewStream(ctx, ha.ID(), testProtocolID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,31 @@
+package noise
+
+import "io"
+
+// fillBuffer reads from the given reader until the given buffer
+// is full
+func fillBuffer(buf []byte, reader io.Reader) (int, error) {
+	total := 0
+	for total < len(buf) {
+		c, err := reader.Read(buf[total:])
+		if err != nil {
+			return total, err
+		}
+		total += c
+	}
+	return total, nil
+}
+
+// writeAll is a helper that writes to the given io.Writer until all input data
+// has been written
+func writeAll(writer io.Writer, data []byte) (int, error) {
+	total := 0
+	for total < len(data) {
+		c, err := writer.Write(data[total:])
+		if err != nil {
+			return total, err
+		}
+		total += c
+	}
+	return total, nil
+}

--- a/xx_handshake.go
+++ b/xx_handshake.go
@@ -27,7 +27,7 @@ func (s *secureSession) xx_sendHandshakeMessage(payload []byte, initial_stage bo
 		return fmt.Errorf("xx_sendHandshakeMessage write length err=%s", err)
 	}
 
-	_, err = s.insecure.Write(encMsgBuf)
+	_, err = writeAll(s.insecure, encMsgBuf)
 	if err != nil {
 		log.Error("xx_sendHandshakeMessage initiator=%v err=%s", s.initiator, err)
 		return fmt.Errorf("xx_sendHandshakeMessage write to conn err=%s", err)
@@ -46,7 +46,7 @@ func (s *secureSession) xx_recvHandshakeMessage(initial_stage bool) (buf []byte,
 
 	buf = make([]byte, l)
 
-	_, err = s.insecure.Read(buf)
+	_, err = fillBuffer(buf, s.insecure)
 	if err != nil {
 		return buf, nil, false, fmt.Errorf("xx_recvHandshakeMessage read from conn err=%s", err)
 	}


### PR DESCRIPTION
Hopefully closes #37 

I noticed that when reading from and writing to the underlying insecure `Conn`, the length return value was always being ignored. I believe this was causing issues when sending large amounts of data, since the code was assuming we'd always read enough data to fill the buffer in a single call to `insecure.Read`, while there are no guarantees about that.

I added `fillBuffer` and `writeAll` helpers to loop until `insecure.Read` fills our input buffer and `insecure.Write` completely writes the output buffer. There may be something already in the stdlib, but it was hard to google for and easy to write 😄

I think this fixes the stream reset errors that were being caused by decryption failures. I changed the integration test to send a large amount of random data. Before the read/write change, I was reliably getting failures when sending more than `1 << 22` bytes. Now it seems I can send as much as I want; I've tested locally with `1 << 32`, but left it at `1 << 24` in the integration test so that it doesn't take forever to run.

In the testground plan mentioned in #37, I'm still seeing some "broken pipe" write errors, but they aren't causing the test to fail, so I think that may be a separate issue.