### PR TITLE
Remove distracting error logs & propagate fatal errors

### DIFF
--- a/ik_handshake.go
+++ b/ik_handshake.go
@@ -3,6 +3,7 @@ package noise
 import (
 	"context"
 	"fmt"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"io"
 
 	proto "github.com/gogo/protobuf/proto"
@@ -117,10 +118,12 @@ func (s *secureSession) runHandshake_ik(ctx context.Context, payload []byte) ([]
 			return buf, fmt.Errorf("runHandshake_ik stage=1 initiator=true err=read remote libp2p key fail")
 		}
 
-		// assert that remote peer ID matches libp2p key
-		err = s.setRemotePeerID(s.RemotePublicKey())
-		if err != nil {
-			return buf, fmt.Errorf("runHandshake_ik stage=1 initiator=true err=%s", err)
+		// assert that remote peer ID matches libp2p public key
+		pid, err := peer.IDFromPublicKey(s.RemotePublicKey())
+		if pid != s.remotePeer {
+			return buf, fmt.Errorf("runHandshake_ik stage=1 initiator=true  check remote peer id err: expected %x got %x", s.remotePeer, pid)
+		} else if err != nil {
+			return buf, fmt.Errorf("runHandshake_ik stage=1 initiator=true  check remote peer id err %s", err)
 		}
 
 		// verify payload is signed by libp2p key

--- a/ik_handshake.go
+++ b/ik_handshake.go
@@ -20,8 +20,6 @@ func (s *secureSession) ik_sendHandshakeMessage(payload []byte, initial_stage bo
 		encMsgBuf = msgbuf.Encode1()
 	}
 
-	log.Debugf("ik_sendHandshakeMessage initiator=%v msgbuf=%v", s.initiator, msgbuf)
-
 	err := s.writeLength(len(encMsgBuf))
 	if err != nil {
 		return fmt.Errorf("ik_sendHandshakeMessage write length err=%s", err)
@@ -56,8 +54,6 @@ func (s *secureSession) ik_recvHandshakeMessage(initial_stage bool) (buf []byte,
 		msgbuf, err = ik.Decode1(buf)
 	}
 
-	log.Debugf("ik_recvHandshakeMessage initiator=%v msgbuf=%v", s.initiator, msgbuf)
-
 	if err != nil {
 		return buf, nil, false, fmt.Errorf("ik_recvHandshakeMessage decode msg fail: %s", err)
 	}
@@ -78,8 +74,6 @@ func (s *secureSession) ik_recvHandshakeMessage(initial_stage bool) (buf []byte,
 // returns last successful message upon error
 func (s *secureSession) runHandshake_ik(ctx context.Context, payload []byte) ([]byte, error) {
 	kp := ik.NewKeypair(s.noiseKeypair.publicKey, s.noiseKeypair.privateKey)
-
-	log.Debugf("runHandshake_ik initiator=%v pubkey=%x", kp.PubKey(), s.initiator)
 
 	remoteNoiseKey := s.noiseStaticKeyCache.Load(s.remotePeer)
 
@@ -181,7 +175,5 @@ func (s *secureSession) runHandshake_ik(ctx context.Context, payload []byte) ([]
 		}
 
 	}
-
-	log.Debugf("runHandshake_ik done initiator=%v", s.initiator)
 	return nil, nil
 }

--- a/protocol.go
+++ b/protocol.go
@@ -170,7 +170,6 @@ func (s *secureSession) runHandshake(ctx context.Context) error {
 	noise_pub := s.noiseKeypair.publicKey
 	signedPayload, err := s.localKey.Sign(append([]byte(payload_string), noise_pub[:]...))
 	if err != nil {
-		log.Errorf("runHandshake signing payload err=%s", err)
 		return fmt.Errorf("runHandshake signing payload err=%s", err)
 	}
 
@@ -180,7 +179,6 @@ func (s *secureSession) runHandshake(ctx context.Context) error {
 	payload.IdentitySig = signedPayload
 	payloadEnc, err := proto.Marshal(payload)
 	if err != nil {
-		log.Errorf("runHandshake marshal payload err=%s", err)
 		return fmt.Errorf("runHandshake proto marshal payload err=%s", err)
 	}
 
@@ -195,12 +193,9 @@ func (s *secureSession) runHandshake(ctx context.Context) error {
 		// we're either a responder or an initiator with a known static key for the remote peer, try IK
 		buf, err := s.runHandshake_ik(ctx, payloadEnc)
 		if err != nil {
-			log.Error("runHandshake ik err=%s", err)
-
 			// IK failed, pipe to XXfallback
 			err = s.runHandshake_xx(ctx, true, payloadEnc, buf)
 			if err != nil {
-				log.Error("runHandshake xx err=err", err)
 				return fmt.Errorf("runHandshake xx err=%s", err)
 			}
 
@@ -212,7 +207,6 @@ func (s *secureSession) runHandshake(ctx context.Context) error {
 		// unknown static key for peer, try XX
 		err := s.runHandshake_xx(ctx, false, payloadEnc, nil)
 		if err != nil {
-			log.Error("runHandshake xx err=%s", err)
 			return err
 		}
 
@@ -262,13 +256,11 @@ func (s *secureSession) Read(buf []byte) (int, error) {
 		ciphertext := make([]byte, l)
 		_, err = io.ReadFull(s.insecure, ciphertext)
 		if err != nil {
-			log.Error("read ciphertext err", err)
 			return 0, err
 		}
 
 		plaintext, err := s.Decrypt(ciphertext)
 		if err != nil {
-			log.Error("decrypt err", err)
 			return 0, err
 		}
 
@@ -328,13 +320,11 @@ func (s *secureSession) Write(in []byte) (int, error) {
 	writeChunk := func(in []byte) (int, error) {
 		ciphertext, err := s.Encrypt(in)
 		if err != nil {
-			log.Error("encrypt error", err)
 			return 0, err
 		}
 
 		err = s.writeLength(len(ciphertext))
 		if err != nil {
-			log.Error("write length err: ", err)
 			return 0, err
 		}
 

--- a/protocol.go
+++ b/protocol.go
@@ -147,8 +147,6 @@ func (s *secureSession) verifyPayload(payload *pb.NoiseHandshakePayload, noiseKe
 	sig := payload.GetIdentitySig()
 	msg := append([]byte(payload_string), noiseKey[:]...)
 
-	log.Debugf("verifyPayload msg=%x", msg)
-
 	ok, err := s.RemotePublicKey().Verify(msg, sig)
 	if err != nil {
 		return err


### PR DESCRIPTION
This removes a ton of calls to `log.Error`, since essentially all errors were being logged, including recoverable errors. This was leading to a lot of irrelevant log output when trying to use noise in a "real" context, e.g. with ipfs.

I also removed the debug logs, since they were logging entire message buffers and don't provide a ton of value, IMO.

More importantly, there were two cases where errors were just being logged, but were otherwise being ignored:

- when the remote peer ID doesn't match the expected ID
- when the handshake payload fails to validate

The last one is especially concerning 😄