### PR TITLE
fix: don't compare a secret key against the zero value

### DIFF
--- a/ik_handshake.go
+++ b/ik_handshake.go
@@ -76,14 +76,14 @@ func (s *secureSession) ik_recvHandshakeMessage(initial_stage bool) (buf []byte,
 func (s *secureSession) runHandshake_ik(ctx context.Context, payload []byte) ([]byte, error) {
 	kp := ik.NewKeypair(s.noiseKeypair.publicKey, s.noiseKeypair.privateKey)
 
-	remoteNoiseKey := s.noiseStaticKeyCache.Load(s.remotePeer)
+	remoteNoiseKey, hasKey := s.noiseStaticKeyCache.Load(s.remotePeer)
 
 	// new IK noise session
 	s.ik_ns = ik.InitSession(s.initiator, s.prologue, kp, remoteNoiseKey)
 
 	if s.initiator {
 		// bail out early if we don't know the remote Noise key
-		if remoteNoiseKey == [32]byte{} {
+		if !hasKey {
 			return nil, fmt.Errorf("runHandshake_ik aborting - unknown static key for peer %s", s.remotePeer.Pretty())
 		}
 

--- a/keycache.go
+++ b/keycache.go
@@ -23,8 +23,9 @@ func (kc *KeyCache) Store(p peer.ID, key [32]byte) {
 	kc.lock.Unlock()
 }
 
-func (kc *KeyCache) Load(p peer.ID) [32]byte {
+func (kc *KeyCache) Load(p peer.ID) (key [32]byte, ok bool) {
 	kc.lock.RLock()
 	defer kc.lock.RUnlock()
-	return kc.m[p]
+	key, ok = kc.m[p]
+	return key, ok
 }

--- a/protocol.go
+++ b/protocol.go
@@ -184,8 +184,9 @@ func (s *secureSession) runHandshake(ctx context.Context) error {
 	// The exception is when we're the initiator and don't know the other party's
 	// static Noise key. Then IK will always fail, so we go straight to XX.
 	tryIK := s.noisePipesSupport
-	if s.initiator && s.noiseStaticKeyCache.Load(s.remotePeer) == [32]byte{} {
-		tryIK = false
+	if tryIK && s.initiator {
+		// We need a key.
+		_, tryIK = s.noiseStaticKeyCache.Load(s.remotePeer)
 	}
 	if tryIK {
 		// we're either a responder or an initiator with a known static key for the remote peer, try IK


### PR DESCRIPTION
1. It's slow(er) to compare 32 bytes against 0.
2. We'd need to use a constant time compare to be safe. It's safer to just use a bool.