### PR TITLE
implement an early data API

### DIFF
--- a/crypto_test.go
+++ b/crypto_test.go
@@ -93,7 +93,7 @@ func TestCryptoFailsIfHandshakeIncomplete(t *testing.T) {
 	init, resp := net.Pipe()
 	_ = resp.Close()
 
-	session, _ := newSecureSession(initTransport, context.TODO(), init, "remote-peer", true)
+	session, _ := newSecureSession(initTransport, context.TODO(), init, "remote-peer", true, nil)
 	_, err := session.encrypt(nil, []byte("hi"))
 	if err == nil {
 		t.Error("expected encryption error when handshake incomplete")

--- a/transport.go
+++ b/transport.go
@@ -14,34 +14,60 @@ const ID = "/noise"
 
 var _ sec.SecureTransport = &Transport{}
 
+type Option func(*Transport) error
+
+// WithEarlyDataHandler specifies a handler for early data sent by the initiator.
+// If the error returned is non-nil, the handshake is aborted.
+func WithEarlyDataHandler(h func([]byte) error) Option {
+	return func(t *Transport) error {
+		t.earlyDataHandler = h
+		return nil
+	}
+}
+
 // Transport implements the interface sec.SecureTransport
 // https://godoc.org/github.com/libp2p/go-libp2p-core/sec#SecureConn
 type Transport struct {
 	localID    peer.ID
 	privateKey crypto.PrivKey
+
+	earlyDataHandler func([]byte) error
 }
 
 // New creates a new Noise transport using the given private key as its
 // libp2p identity key.
-func New(privkey crypto.PrivKey) (*Transport, error) {
+func New(privkey crypto.PrivKey, opts ...Option) (*Transport, error) {
 	localID, err := peer.IDFromPrivateKey(privkey)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Transport{
+	t := &Transport{
 		localID:    localID,
 		privateKey: privkey,
-	}, nil
+	}
+	for _, opt := range opts {
+		if err := opt(t); err != nil {
+			return nil, err
+		}
+	}
+
+	return t, nil
 }
 
 // SecureInbound runs the Noise handshake as the responder.
 // If p is empty, connections from any peer are accepted.
 func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	return newSecureSession(t, ctx, insecure, p, false)
+	return newSecureSession(t, ctx, insecure, p, false, nil)
 }
 
 // SecureOutbound runs the Noise handshake as the initiator.
 func (t *Transport) SecureOutbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	return newSecureSession(t, ctx, insecure, p, true)
+	return newSecureSession(t, ctx, insecure, p, true, nil)
+}
+
+// SecureOutboundWithEarlyData runs the Noise handshake as the initiator.
+// earlyData is sent (unencrypted!) along with the first handshake message.
+func (t *Transport) SecureOutboundWithEarlyData(ctx context.Context, insecure net.Conn, p peer.ID, earlyData []byte) (sec.SecureConn, error) {
+	return newSecureSession(t, ctx, insecure, p, true, earlyData)
 }


### PR DESCRIPTION
This API is not very sophisticated, in particular, it doesn't implement the proposal discussed in libp2p/go-libp2p#1537. It only implements the bare minimum we need for the WebTransport handshake (see https://github.com/libp2p/specs/pull/404#discussion_r849834357 for details).

The client can send (unencrypted, but integrity-protected) data along the first handshake message, and the server can read that data and decide if it wants to abort the handshake.